### PR TITLE
Modifying cached-image to respect headers

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -113,12 +113,13 @@ const CachedImage = React.createClass({
 
     processSource(source) {
         const url = _.get(source, ['uri'], null);
+        const headers = _.get(source, ['headers'], null);
         if (ImageCacheProvider.isCacheable(url)) {
             const options = _.pick(this.props, ['useQueryParamsInCacheKey', 'cacheGroup']);
             // try to get the image path from cache
             ImageCacheProvider.getCachedImagePath(url, options)
                 // try to put the image in cache if
-                .catch(() => ImageCacheProvider.cacheImage(url, options))
+                .catch(() => ImageCacheProvider.cacheImage(url, headers, options))
                 .then(cachedImagePath => {
                     this.safeSetState({
                         cachedImagePath

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -90,14 +90,15 @@ function ensurePath(filePath) {
  * @param toFile
  * @returns {Promise}
  */
-function downloadImage(fromUrl, toFile) {
+function downloadImage(fromUrl, headers, toFile) {
     // use toFile as the key as is was created using the cacheKey
     if (!_.has(activeDownloads, toFile)) {
         // create an active download for this file
         activeDownloads[toFile] = new Promise((resolve, reject) => {
             const downloadOptions = {
                 fromUrl,
-                toFile
+                toFile,
+                headers
             };
             RNFS.downloadFile(downloadOptions).promise
                 .then(res => {
@@ -139,7 +140,7 @@ function runPrefetchTask(prefetcher, options) {
         // check cache
         return getCachedImagePath(url, options)
         // if not found download
-            .catch(() => cacheImage(url, options))
+            .catch(() => cacheImage(url, null, options))
             // then run next task
             .then(() => runPrefetchTask(prefetcher, options));
     }
@@ -175,10 +176,10 @@ function getCachedImagePath(url, options = defaultOptions) {
         })
 }
 
-function cacheImage(url, options = defaultOptions) {
+function cacheImage(url, headers, options = defaultOptions) {
     const filePath = getCachedImageFilePath(url, options);
     return ensurePath(filePath)
-        .then(() => downloadImage(url, filePath));
+        .then(() => downloadImage(url, headers, filePath));
 }
 
 function deleteCachedImage(url, options = defaultOptions) {


### PR DESCRIPTION
I've been attempting to use your CachedImage library in a situation where my image was secured, and I wanted to pass it an authorization header the same way I would for the normal react-native <Image> tag (which itself is a fairly recent fix). It appears like that information was being stripped out before the download was happening, so I modified the code to pass it through.

I suspect this almost certainly is not the right fix, because (a) it is special casing the headers - any other information that's not the uri or the header is still being dropped on the floor, and (b) doesn't handle the prefetch task, which I wasn't sure how to fix.

I'd really like to not have to use a fork of your library, because otherwise it does exactly what I need. If it's obvious to you how the right fix should look, or are interested in just taking this one as a pareto improvement, let me know...I'm happy to help get this merged.

Andy